### PR TITLE
Add missing jstl dependency

### DIFF
--- a/src/main/resources/templates/module/pom.xml
+++ b/src/main/resources/templates/module/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>bennu-spring</artifactId>
             <version>${version.org.fenixedu.bennu.spring}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <version>1.2</version>
+        </dependency>
         {% endif %}
     </dependencies>
 


### PR DESCRIPTION
For this example to work as is, the module must depend on jstl api.
Maybe bennu-spring should depend on this directly.
@jcarvalho what do you think ?